### PR TITLE
added CURLOPT_USERAGENT (User-Agent header)

### DIFF
--- a/bin/gfm.php
+++ b/bin/gfm.php
@@ -12,6 +12,7 @@ $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, "https://api.github.com/markdown");
 curl_setopt($ch, CURLOPT_POST, 1);
 curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json"));
+curl_setopt($ch, CURLOPT_USERAGENT, "gfm-preview");
 curl_setopt($ch, CURLOPT_POSTFIELDS, $req);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
Thanks for the plug-in! In order to get it to work however I needed to add an HTTP header (User-Agent) to the request to get it to comply with GitHub's API.
