### PR TITLE
added user-agent header to comply with GitHub rules

### DIFF
--- a/bin/gfm.php
+++ b/bin/gfm.php
@@ -11,7 +11,7 @@ $req = json_encode(array("text" => $doc, "mode" => "gfm"));
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, "https://api.github.com/markdown");
 curl_setopt($ch, CURLOPT_POST, 1);
-curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json"));
+curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/json", "User-Agent: TextMate-1.5"));
 curl_setopt($ch, CURLOPT_POSTFIELDS, $req);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
GitHub has added a requirement that these sorts of requests include a User-Agent header. Added this, tested it locally, and it works as advertised. Very nice addition to my toolbox.
